### PR TITLE
Fix most clippy lints and use PathBuf instead of String

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use home::home_dir;
 use l1t::level::*;
 use l1t::menu::*;
 use l1t::userdata::*;
-use std::io::stdout;
+use std::{io::stdout, path::PathBuf};
 use std::{thread, time};
 
 const SLEEP_TIME: u64 = 500;
@@ -19,7 +19,7 @@ const SLEEP_TIME: u64 = 500;
 struct Args {
     /// The `.l1t` file to load a level from
     #[arg(short, long)]
-    file: Option<String>,
+    file: Option<PathBuf>,
     ///// Repository to download levels from
     //#[arg(short, long)]
     //repo_url: Option<String>,
@@ -33,7 +33,7 @@ fn main() {
     if let Some(filename) = &args.file {
         // File has been provided
         loop {
-            let mut level = match Level::file(filename.to_string()) {
+            let mut level = match Level::file(filename.as_path()) {
                 Ok(l) => l,
                 Err(e) => {
                     eprintln!("{e}");
@@ -86,8 +86,7 @@ fn main() {
         Some(h) => h,
         None => return,
     };
-    let home = home.to_str().unwrap_or("");
-    let mut user_data = match UserData::read(home.to_string()) {
+    let mut user_data = match UserData::read(&home) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("{e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,12 +124,9 @@ fn main() {
                                 thread::sleep(time::Duration::from_millis(SLEEP_TIME));
                                 Menu::open(MenuType::Message("YAY, You Won!".to_string()));
                                 current_level += 1;
-                                match user_data.complete_core(current_level as usize) {
-                                    Err(e) => {
-                                        eprintln!("{e}");
-                                        return;
-                                    }
-                                    _ => (),
+                                if let Err(e) = user_data.complete_core(current_level) {
+                                    eprintln!("{e}");
+                                    return;
                                 };
                             } else if let Some(r) = result.reason_for_loss {
                                 match r {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -205,8 +205,8 @@ impl Menu {
                         )
                         .ok();
                     }
-                    match read().unwrap() {
-                        Event::Key(event) => match event.code {
+                    if let Event::Key(event) = read().unwrap() {
+                        match event.code {
                             KeyCode::Enter => match options[current_selection] {
                                 Selection::Play(_) => {
                                     if let Some(Selection::Item(i)) = Menu::open(
@@ -229,8 +229,7 @@ impl Menu {
                             }
                             KeyCode::Char('q') => return Some(Selection::Quit),
                             _ => (),
-                        },
-                        _ => (),
+                        }
                     }
                 }
                 return Some(options[current_selection].clone());
@@ -251,12 +250,10 @@ impl Menu {
                         Print(message.clone()),
                     )
                     .ok();
-                    match read().unwrap() {
-                        Event::Key(event) => match event.code {
-                            KeyCode::Enter => break,
-                            _ => (),
-                        },
-                        _ => (),
+                    if let Event::Key(event) = read().unwrap() {
+                        if let KeyCode::Enter = event.code {
+                            break;
+                        }
                     }
                 }
             }
@@ -305,8 +302,8 @@ impl Menu {
                         Print(" NO ".bold())
                     )
                     .ok();
-                    match read().unwrap() {
-                        Event::Key(event) => match event.code {
+                    if let Event::Key(event) = read().unwrap() {
+                        match event.code {
                             KeyCode::Left
                             | KeyCode::Right
                             | KeyCode::Char('a')
@@ -322,12 +319,11 @@ impl Menu {
                             KeyCode::Char('q') => return Some(Selection::No),
                             KeyCode::Enter => return Some(current_selection),
                             _ => (),
-                        },
-                        _ => (),
+                        }
                     }
                 }
             }
-            MenuType::HelpMenu => loop {
+            MenuType::HelpMenu => {
                 return Menu::open(MenuType::ScrollableMenu(vec![
                     vec![
                         "l1t".bold().green(),
@@ -519,7 +515,7 @@ impl Menu {
                     vec!["            blocks on/off. Player must be".stylize()],
                     vec!["            next to button to press.".stylize()],
                 ]));
-            },
+            }
             MenuType::ScrollableMenu(content) => {
                 let row_padding = 1;
                 let col_padding = 2;
@@ -553,8 +549,8 @@ impl Menu {
                             execute!(stdout(), Print(piece)).ok();
                         }
                     }
-                    match read().unwrap() {
-                        Event::Key(event) => match event.code {
+                    if let Event::Key(event) = read().unwrap() {
+                        match event.code {
                             KeyCode::Up | KeyCode::Char('w') | KeyCode::Char('k') => {
                                 if start_index == 0 {
                                     continue;
@@ -571,8 +567,7 @@ impl Menu {
                             KeyCode::Char('G') => start_index = content.len() - lines,
                             KeyCode::Enter | KeyCode::Char('q') => break,
                             _ => (),
-                        },
-                        _ => (),
+                        }
                     }
                 }
             }
@@ -642,8 +637,8 @@ impl Menu {
                             .ok();
                         }
                     }
-                    match read().unwrap() {
-                        Event::Key(event) => match event.code {
+                    if let Event::Key(event) = read().unwrap() {
+                        match event.code {
                             KeyCode::Left | KeyCode::Char('a') | KeyCode::Char('h') => {
                                 if current_selection as isize - 1 < 0 {
                                     current_selection = highest_completed_level;
@@ -663,8 +658,7 @@ impl Menu {
                             }
                             KeyCode::Enter => return Some(Selection::Item(current_selection)),
                             _ => (),
-                        },
-                        _ => (),
+                        }
                     }
                 }
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -261,26 +261,23 @@ impl Node {
 
     pub fn draw_overlay(&self, offset: (u16, u16)) -> crossterm::Result<()> {
         let mut stdout = stdout();
-        match &self.node_type {
-            NodeType::Laser(l) => {
-                if l.shooting_at.len() == 0 {
-                    return Ok(());
-                }
-                for i in 0..(l.shooting_at.len() - 1) {
-                    let pos = l.shooting_at[i];
-                    execute!(
-                        stdout,
-                        SetForegroundColor(Color::Rgb { r: 255, g: 0, b: 0 }),
-                        MoveTo(pos.1 + offset.1, pos.0 + offset.0),
-                    )?;
-                    if i == l.shooting_at.len() - 2 {
-                        execute!(stdout, Print(pos.3.bold()),)?;
-                    } else {
-                        execute!(stdout, Print(pos.2.bold()),)?;
-                    }
+        if let NodeType::Laser(l) = &self.node_type {
+            if l.shooting_at.is_empty() {
+                return Ok(());
+            }
+            for i in 0..(l.shooting_at.len() - 1) {
+                let pos = l.shooting_at[i];
+                execute!(
+                    stdout,
+                    SetForegroundColor(Color::Rgb { r: 255, g: 0, b: 0 }),
+                    MoveTo(pos.1 + offset.1, pos.0 + offset.0),
+                )?;
+                if i == l.shooting_at.len() - 2 {
+                    execute!(stdout, Print(pos.3.bold()),)?;
+                } else {
+                    execute!(stdout, Print(pos.2.bold()),)?;
                 }
             }
-            _ => (),
         };
         execute!(stdout, ResetColor)
     }
@@ -489,9 +486,8 @@ impl Node {
     }
 
     pub fn set_shooting_at(&mut self, shooting_at: Vec<(u16, u16, char, char)>) {
-        match &mut self.node_type {
-            NodeType::Laser(l) => l.shooting_at = shooting_at,
-            _ => (),
+        if let NodeType::Laser(l) = &mut self.node_type {
+            l.shooting_at = shooting_at
         }
     }
 }

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -20,9 +20,8 @@ impl UserData {
     pub fn read(home_dir: String) -> Result<UserData, String> {
         let filename = home_dir.to_string() + "/.l1t/data.json";
         if !path::Path::new(&filename).exists() {
-            match fs::create_dir(home_dir + "/.l1t") {
-                Err(e) => return Err(e.to_string()),
-                _ => (),
+            if let Err(e) = fs::create_dir(home_dir + "/.l1t") {
+                return Err(e.to_string());
             };
             let data = UserData {
                 file: filename.clone(),
@@ -33,9 +32,8 @@ impl UserData {
                 Ok(c) => c,
                 Err(e) => return Err(e.to_string()),
             };
-            match fs::write(&filename, content) {
-                Err(e) => return Err(e.to_string()),
-                _ => (),
+            if let Err(e) = fs::write(&filename, content) {
+                return Err(e.to_string());
             };
         }
         let file_content = fs::read_to_string(&filename).unwrap_or("".to_string());
@@ -46,7 +44,7 @@ impl UserData {
     }
 
     pub fn complete_core(&mut self, level: usize) -> Result<(), String> {
-        if self.completed_core_levels.iter().position(|i| *i == level) != None {
+        if self.completed_core_levels.iter().any(|i| *i == level) {
             return Ok(());
         }
         self.completed_core_levels.push(level);
@@ -54,9 +52,8 @@ impl UserData {
             Ok(c) => c,
             Err(e) => return Err(e.to_string()),
         };
-        match fs::write(&self.file, content) {
-            Err(e) => return Err(e.to_string()),
-            _ => (),
+        if let Err(e) = fs::write(&self.file, content) {
+            return Err(e.to_string());
         };
         Ok(())
     }

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{fs, path};
+use std::{
+    fs,
+    path::{self, Path, PathBuf},
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompletedLevel {
@@ -11,16 +14,17 @@ pub struct CompletedLevel {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UserData {
-    file: String,
+    #[serde(skip)]
+    file: PathBuf,
     pub completed_core_levels: Vec<usize>,
     pub completed_levels: Vec<CompletedLevel>,
 }
 
 impl UserData {
-    pub fn read(home_dir: String) -> Result<UserData, String> {
-        let filename = home_dir.to_string() + "/.l1t/data.json";
+    pub fn read(home_dir: &Path) -> Result<UserData, String> {
+        let filename = home_dir.join("/.l1t/data.json");
         if !path::Path::new(&filename).exists() {
-            if let Err(e) = fs::create_dir(home_dir + "/.l1t") {
+            if let Err(e) = fs::create_dir(home_dir.join("/.l1t")) {
                 return Err(e.to_string());
             };
             let data = UserData {


### PR DESCRIPTION
Fix [clippy](https://github.com/rust-lang/rust-clippy) lints.
Use Path and PathBuf for paths and path operations.
Seperate playing options into seperate functions to remove duplicete code to show cursor and clear screen.